### PR TITLE
Remove vim, git and postgresql-client on Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,6 @@ FROM python:3.6.3-jessie
 EXPOSE 80
 EXPOSE 443
 
-RUN \
-	apt-get update; \
-	apt-get install -y postgresql-client vim git
-
 ENV HOME=/home/hot
 WORKDIR $HOME
 


### PR DESCRIPTION
This commit removes the installation of vim, git and pgsql. This will reduce the docker image size when compiled