### PR TITLE
deprecate notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A service that integrates ML models to applications like Tasking Manager.
 
+# **ML Enabler is now maintained and developed by Development Seed.**
+
+* [Repository](https://github.com/developmentseed/ml-enabler)
+* [Roadmap for version 3](https://github.com/developmentseed/ml-enabler/issues/4)
+
+
+----
 ## Background
 Machine Learning has proven to be very successful to make mapping fast with high quality. With a diverse set of models and tools, it is hard to integrate them to existing tools like Tasking Manager and iD. HOT is developing ml-enabler to enable AI-assist to existing mapping tools.
 


### PR DESCRIPTION
Based my conversation with @willemarcel and @bopercival-hot, we're moving maintenance and further development of ML Enabler under the Development Seed repo. Since the first release of ML Enabler, Development Seed has pushed quite a few features and moved the project ahead that it will be hard to reconcile the forks.

If you are using ML Enabler, we encourage you to grab the latest release from https://github.com/developmentseed/ml-enabler and take a look at the road map here https://github.com/developmentseed/ml-enabler/issues/4